### PR TITLE
 Using it with a local Ollama Model(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ python tempest_pipeline.py --target_model <target_model> --pipeline_model <pipel
 python get_metrics.py <results_json>
 ```
 
+#### Using a Local Ollama Model
+
+If you run a model locally with [Ollama](https://github.com/ollama/ollama), prefix the
+model name with `local/` and ensure the Ollama server is running. For example:
+
+```bash
+# Use a locally hosted DeepSeek model
+python tempest_pipeline.py --target_model local/deepseek-llm-r1-8b --pipeline_model local/deepseek-llm-r1-8b --results_json results.json
+```
+
+Set the `OLLAMA_BASE_URL` environment variable if your server is not available at
+`http://localhost:11434`.
+
 ## 6. Citation
 
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -136,7 +136,14 @@ python csrf_train_instruct.py --output_dir <output_dir> --run_eval
 ### Tempest
 
 ```bash
-cd ../tempest
+# Move back to the repository root
+cd ..
+
+# Install Tempest dependencies
+pip install -r tempest/requirements.txt
+
+# Enter the Tempest directory
+cd tempest
 
 # Run Tempest on a target model
 python tempest_pipeline.py --target_model <target_model> --pipeline_model <pipeline_model> --results_json <results_json>

--- a/tempest/conversation_attack.py
+++ b/tempest/conversation_attack.py
@@ -808,6 +808,17 @@ def llmclient_generate_conversation(self, messages: List[Dict[str, str]], max_to
         conversation_text += "Assistant:"
         response = self.generate(conversation_text, max_tokens=max_tokens, temperature=temperature)
         return response.strip()
+
+    elif self.client_type == "ollama":
+        url = f"{self.base_url}/api/chat"
+        data = {"model": self.model_name, "messages": messages, "stream": False, "temperature": temperature, "num_predict": max_tokens}
+        response = self.session.post(url, json=data)
+        response.raise_for_status()
+        res_json = response.json()
+        if isinstance(res_json, dict):
+            message = res_json.get("message") or {}
+            return message.get("content", res_json.get("response", "")).strip()
+        return ""
     else:
         raise ValueError(f"Client type {self.client_type} does not support conversation format.")
 

--- a/tempest/requirements.txt
+++ b/tempest/requirements.txt
@@ -1,0 +1,6 @@
+openai
+anthropic
+requests
+tenacity
+datasets
+pandas


### PR DESCRIPTION
Introduced an “ollama” client type to connect with locally hosted models by detecting names prefixed with “local/” or “ollama/,” storing the base URL in OLLAMA_BASE_URL, and using a requests session

Added logic for generating text and handling conversations via the Ollama API in the LLM client, supporting both prompt-based and chat interactions

Documented how to run Tempest with a locally hosted DeepSeek model and how to adjust the Ollama server URL in the README